### PR TITLE
Remove unused basic info element

### DIFF
--- a/post.hbs
+++ b/post.hbs
@@ -17,16 +17,6 @@
 			      <ul class="author-list post">
 			      {{#foreach authors}}
 			          <li class="author-list-item">
-			              <div class="author-card">
-			                  <div class="bio">
-			                      {{#if bio}}
-			                          <p>{{bio}}</p>
-			                          <p><a href="{{url}}">More posts</a> by {{name}}.</p>
-			                      {{else}}
-			                          <p>Read <a href="{{url}}">more posts</a> by this author.</p>
-			                      {{/if}}
-			                  </div>
-			              </div>
 			              {{#if profile_image}}
 			                  <a href="{{url}}" class="moving-avatar"><img class="author-profile-image" src="{{profile_image}}" alt="{{name}}" /></a>
 			              {{else}}

--- a/post.hbs
+++ b/post.hbs
@@ -18,14 +18,6 @@
 			      {{#foreach authors}}
 			          <li class="author-list-item">
 			              <div class="author-card">
-			                  <div class="basic-info">
-			                      {{#if profile_image}}
-			                          <img class="author-profile-image" src="{{profile_image}}" alt="{{name}}" />
-			                      {{else}}
-			                          <div class="author-profile-image">{{> "icons/avatar"}}</div>
-			                      {{/if}}
-			                      <h2>{{name}}</h2>
-			                  </div>
 			                  <div class="bio">
 			                      {{#if bio}}
 			                          <p>{{bio}}</p>


### PR DESCRIPTION
Removes a seemingly unused div that was creating some funky behavior near the bottom of all blog posts.